### PR TITLE
fix usage of setsid

### DIFF
--- a/lib/Test/NoTty.pm
+++ b/lib/Test/NoTty.pm
@@ -47,7 +47,7 @@ sub without_tty(&@) {
 
         eval {
             die "setsid failed: $!"
-                unless setsid;
+                if setsid == -1;
 
             # Likewise, a limitation is that the only function return value we
             # can easily support is an integer process exit code:


### PR DESCRIPTION
POSIX::setsid returns -1, not undef on failure:

```
❯ perl -MPOSIX -le 'my $ret = POSIX::setsid; print "$ret: $!"'
-1: Operation not permitted
```